### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -7,10 +7,10 @@
 #######################################
 
 EventFuse	KEYWORD1
-FuseID  KEYWORD1
-eventFuseCallback_t KEYWORD1
-FuseState KEYWORD1
-eventFuse_t KEYWORD1
+FuseID	KEYWORD1
+eventFuseCallback_t	KEYWORD1
+FuseState	KEYWORD1
+eventFuse_t	KEYWORD1
 
 
 #######################################


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords